### PR TITLE
Fix complexity

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -40,6 +40,9 @@ excluded:
 
 line_length: 128
 
+cyclomatic_complexity:
+  ignores_case_statements: true
+
 type_body_length:
   - 500 # warning
   - 700 # error


### PR DESCRIPTION
For so long switch / case. Code below will not pass linter without this flag. 

```swift
init(value: String) {
        switch value {
        case "AWAITING": self = .awaiting
        case "NEW": self = .new
        case "CONFIRMED": self = .confirmed
        case "CANCELLED_BY_BUYER": self = .canceledByBuyer
        case "CANCELLED_BY_BROKER": self = .canceledByBroker
        case "CANCELLED_BY_OPERATOR": self = .canceledByOperator
        case "INVALIDATED_BY_BROKER": self = .invalidatedByBroker
        case "PROCEED_BY_BROKER": self = .proceedByBroker
        case "TIMEOUT": self = .timeout
        case "UNFULFILLED": self = .unfullfilled
        case "DONE": self = .done
        default: self = .undefined
        }
 }
```